### PR TITLE
Return Date object (#38)

### DIFF
--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -1,9 +1,9 @@
 <div class="example-conversions-grid">
-  <div class="unix-converion-example">
+  <div>
+    <p>UNIX CONVERSION EXAMPLE</p>
     <div>
       <app-unix-datepicker
-        [dateFormat]="{ dateStyle: 'full', timeStyle: 'long' }"
-        (dateTimeOutput)="updateDateTime($event)">
+        (unixDateOutput)="unixOutput($event)">
       </app-unix-datepicker>
     </div>
     <div>

--- a/demo/src/app/app.component.scss
+++ b/demo/src/app/app.component.scss
@@ -5,9 +5,3 @@
   gap: 1rem;
   padding: 1rem;
 }
-
-.unix-converion-example {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,18 +1,38 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { UnixDatepickerComponent } from './unix-datepicker/unix-datepicker.component';
+import { DatePipe } from '@angular/common';
 
 @Component({
   selector: 'app-root',
   imports: [UnixDatepickerComponent],
+  providers: [DatePipe],
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })
 export class AppComponent {
+  // Title vars.
   title = 'demo';
 
-  unixTimestampConversion = '';
+  // Pipe vars.
+  datePipe = inject(DatePipe);
 
-  updateDateTime(newDateTime: string): void {
-    this.unixTimestampConversion = newDateTime;
+  // Output storage vars.
+  unixTimestampConversion!: string | null;
+
+  /**
+   * Receives the output from UnixDatepicker component and sets the associated output variable.
+   * @param newDate Date object.
+   */
+  unixOutput(newDate: Date): void {
+    this.unixTimestampConversion = this._formatExampleOutput(newDate);
+  }
+
+  /**
+   * Format Date object input to look something like "2026-02-15 10:23:51.000".
+   * @param date Date object.
+   * @returns Result of DatePipe transform.
+   */
+  private _formatExampleOutput(date: Date): string | null {
+    return this.datePipe.transform(date, 'yyyy-MM-dd hh:mm:ss.SSS z', '+0');
   }
 }

--- a/demo/src/app/unix-datepicker/unix-datepicker.component.ts
+++ b/demo/src/app/unix-datepicker/unix-datepicker.component.ts
@@ -35,13 +35,7 @@ export class UnixDatepickerComponent {
   appearance = input<MatFormFieldAppearance>('fill');
   label = input<string>('Unix');
   placeholder = input<string>('Enter 10 or 13 digit timestamp');
-  useGMT = input(false, {
-    transform: (v: string | boolean) => typeof v === 'string' ? v === 'true' : v
-  });
   debounce = input<number>(DEBOUNCE_TIME_MS);
-  dateFormat = input<Intl.DateTimeFormatOptions>({
-    dateStyle: 'medium'
-  });
 
   // User input.
   timestampForm = new FormGroup({
@@ -85,29 +79,22 @@ export class UnixDatepickerComponent {
     return '';
   });
 
-  readonly dateTimeString = computed(() => {
+  readonly convertedDate = computed(() => {
     // Fires when timestamp FormControl value changes.
     const timestamp = this._timestampSignal();
     if (!timestamp) return '';
 
-    const date = new Date(timestamp);
-    return date.toLocaleString(
-      undefined,
-      {
-        ...this.dateFormat(),
-        timeZone: this.useGMT() ? 'GMT' : undefined
-      }
-    );
+    return new Date(timestamp);
   });
 
   // Component outputs.
-  dateTimeOutput = output<string>();
+  unixDateOutput = output<Date>();
 
   constructor() {
     effect(() => {
-      const dateString = this.dateTimeString();
+      const dateString = this.convertedDate();
       if (dateString) {
-        this.dateTimeOutput.emit(dateString);
+        this.unixDateOutput.emit(dateString);
       }
     });
   }


### PR DESCRIPTION
Removed the inputs for dateFormat and useGMT. Minor style changes. Setup a helper function with DatePipe to use for all future datepicker example outputs.

re #38