### PR TITLE
Use published NPM package (#28)

### DIFF
--- a/demo/package-lock.json
+++ b/demo/package-lock.json
@@ -42,6 +42,7 @@
         "eslint-plugin-no-loops": "^0.4.0",
         "jsdom": "^28.0.0",
         "ng-packagr": "^20.3.2",
+        "ngx-mat-datepicker-pack": "^0.0.1",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.55.0",
         "vitest": "^3.2.4"
@@ -14248,6 +14249,23 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ngx-mat-datepicker-pack": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-mat-datepicker-pack/-/ngx-mat-datepicker-pack-0.0.1.tgz",
+      "integrity": "sha512-wnMRuYn2t+BITa/sGg5iNzNXh4ZSbTPbIcEPfACl/aHo7zpTedGiSESwK9WcxTiUZfwIB20XKWW6uLQZaPAJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "peerDependencies": {
+        "@angular/common": "^20.0.0",
+        "@angular/compiler": "^20.0.0",
+        "@angular/core": "^20.0.0",
+        "@angular/forms": "^20.0.0",
+        "@angular/material": "^20.0.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/demo/package.json
+++ b/demo/package.json
@@ -76,6 +76,7 @@
     "eslint-plugin-no-loops": "^0.4.0",
     "jsdom": "^28.0.0",
     "ng-packagr": "^20.3.2",
+    "ngx-mat-datepicker-pack": "^0.0.1",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.55.0",
     "vitest": "^3.2.4"

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -2,9 +2,9 @@
   <div>
     <p>UNIX CONVERSION EXAMPLE</p>
     <div>
-      <app-unix-datepicker
+      <mdp-unix-datepicker
         (unixDateOutput)="unixOutput($event)">
-      </app-unix-datepicker>
+      </mdp-unix-datepicker>
     </div>
     <div>
       <p>Converted date: {{ unixTimestampConversion }}</p>

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -1,13 +1,13 @@
 import { Component, inject } from '@angular/core';
-import { UnixDatepickerComponent } from './unix-datepicker/unix-datepicker.component';
+import { MdpUnixDatepicker } from 'ngx-mat-datepicker-pack';
 import { DatePipe } from '@angular/common';
 
 @Component({
   selector: 'app-root',
-  imports: [UnixDatepickerComponent],
+  imports: [MdpUnixDatepicker],
   providers: [DatePipe],
   templateUrl: './app.component.html',
-  styleUrl: './app.component.scss'
+  styleUrl: './app.component.scss',
 })
 export class AppComponent {
   // Title vars.

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -26,9 +26,6 @@
     "paths": {
       "ngx-mat-datepicker-pack": [
         "./dist/ngx-mat-datepicker-pack"
-      ],
-      "test-lib": [
-        "./dist/test-lib"
       ]
     }
   },


### PR DESCRIPTION
Demo now utilizes the MdpUnixDatepicker instead of UnixDatepicker

closes #28